### PR TITLE
PHP 7.2 deprecation fixes

### DIFF
--- a/tests/case.php
+++ b/tests/case.php
@@ -76,7 +76,7 @@ abstract class ezcWorkflowDatabaseTieinTestCase extends ezcWorkflowTestCase
             case 'pgsql':
             {
                 $tables = $this->db->query( "SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'" )->fetchAll();
-                array_walk( $tables, create_function( '&$item,$key', '$item = $item[0];' ) );
+                array_walk( $tables, function ( &$item ) { $item = $item[0]; } );
 
                 foreach ( $tables as $tableName )
                 {
@@ -88,7 +88,7 @@ abstract class ezcWorkflowDatabaseTieinTestCase extends ezcWorkflowTestCase
             case 'oracle':
             {
                 $tables = $this->db->query( "SELECT table_name FROM user_tables" )->fetchAll();
-                array_walk( $tables, create_function( '&$item,$key', '$item = $item[0];' ) );
+                array_walk( $tables, function ( &$item ) { $item = $item[0]; } );
 
                 foreach ( $tables as $tableName )
                 {
@@ -96,7 +96,7 @@ abstract class ezcWorkflowDatabaseTieinTestCase extends ezcWorkflowTestCase
                 }
 
                 $sequences = $this->db->query( "SELECT sequence_name FROM user_sequences" )->fetchAll();
-                array_walk( $sequences, create_function( '&$item,$key', '$item = $item[0];' ) );
+                array_walk( $sequences, function ( &$item ) { $item = $item[0]; } );
 
                 foreach ( $sequences as $sequenceName )
                 {

--- a/tests/case.php
+++ b/tests/case.php
@@ -76,7 +76,7 @@ abstract class ezcWorkflowDatabaseTieinTestCase extends ezcWorkflowTestCase
             case 'pgsql':
             {
                 $tables = $this->db->query( "SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'" )->fetchAll();
-                array_walk( $tables, function ( &$item ) { $item = $item[0]; } );
+                array_walk( $tables, function ( &$item, $key ) { $item = $item[0]; } );
 
                 foreach ( $tables as $tableName )
                 {
@@ -88,7 +88,7 @@ abstract class ezcWorkflowDatabaseTieinTestCase extends ezcWorkflowTestCase
             case 'oracle':
             {
                 $tables = $this->db->query( "SELECT table_name FROM user_tables" )->fetchAll();
-                array_walk( $tables, function ( &$item ) { $item = $item[0]; } );
+                array_walk( $tables, function ( &$item, $key ) { $item = $item[0]; } );
 
                 foreach ( $tables as $tableName )
                 {
@@ -96,7 +96,7 @@ abstract class ezcWorkflowDatabaseTieinTestCase extends ezcWorkflowTestCase
                 }
 
                 $sequences = $this->db->query( "SELECT sequence_name FROM user_sequences" )->fetchAll();
-                array_walk( $sequences, function ( &$item ) { $item = $item[0]; } );
+                array_walk( $sequences, function ( &$item, $key ) { $item = $item[0]; } );
 
                 foreach ( $sequences as $sequenceName )
                 {


### PR DESCRIPTION
Fixes:

```
 PHP | File:Line                                                                                          |             Type | Issue
 7.2 | /tests/case.php:79                                                                                 | function         | Function create_function() is deprecated. 
 7.2 | /tests/case.php:91                                                                                 | function         | Function create_function() is deprecated. 
 7.2 | /tests/case.php:99                                                                                 | function         | Function create_function() is deprecated. 
```